### PR TITLE
switch to version@2 android.hardware.bluetooth.audio

### DIFF
--- a/device_framework_compatibility_matrix.xml
+++ b/device_framework_compatibility_matrix.xml
@@ -25,7 +25,7 @@
     </hal>
     <hal format="aidl" optional="true">
         <name>android.hardware.bluetooth.audio</name>
-        <version>1-2</version>
+        <version>2</version>
         <interface>
             <name>IBluetoothAudioProviderFactory</name>
             <instance>default</instance>


### PR DESCRIPTION
Using 2 as  version : 

The following HALs in device manifest are not declared in FCM <= level 3: 
  android.hardware.bluetooth.audio.IBluetoothAudioProviderFactory/default (@2)